### PR TITLE
add LabelsWrapper adaptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.taboola</groupId>
     <artifactId>async-profiler-actuator-endpoint</artifactId>
-    <version>2.0.4</version>
+    <version>2.0.5</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Async Profiler Actuator Endpoint</description>

--- a/src/main/java/com/taboola/async_profiler/api/AsyncProfilerService.java
+++ b/src/main/java/com/taboola/async_profiler/api/AsyncProfilerService.java
@@ -27,7 +27,7 @@ public class AsyncProfilerService {
     private final long continuousProfilingFailureBackoffSeconds;
     private final ThreadUtils threadUtils;
     private final Object lock;
-    private RecurringRunnable currentContinuousProfilingTask;
+    private volatile RecurringRunnable currentContinuousProfilingTask;
 
     public AsyncProfilerService(AsyncProfilerFacade asyncProfilerFacade,
                                 ProfileResultsReporter profileResultsReporter,
@@ -78,6 +78,10 @@ public class AsyncProfilerService {
                 throw new IllegalStateException("There is no active continuous profiling session");
             }
         }
+    }
+
+    public boolean isContinuousProfilingActive() {
+        return currentContinuousProfilingTask != null;
     }
 
     public String getSupportedEvents() {

--- a/src/main/java/com/taboola/async_profiler/api/LabelsWrapper.java
+++ b/src/main/java/com/taboola/async_profiler/api/LabelsWrapper.java
@@ -1,0 +1,30 @@
+package com.taboola.async_profiler.api;
+
+import io.pyroscope.labels.LabelsSet;
+import io.pyroscope.labels.Pyroscope;
+
+import java.util.concurrent.Callable;
+
+public class LabelsWrapper {
+    private static AsyncProfilerService asyncProfilerService;
+
+    public static void setAsyncProfilerService(AsyncProfilerService asyncProfilerService) {
+        LabelsWrapper.asyncProfilerService = asyncProfilerService;
+    }
+
+    public static <T> T run(LabelsSet labels, Callable<T> c) throws Exception {
+        if (asyncProfilerService != null && asyncProfilerService.isContinuousProfilingActive()) {
+            return Pyroscope.LabelsWrapper.run(labels, c);
+        } else {
+            return c.call();
+        }
+    }
+
+    public static void run(LabelsSet labels, Runnable c) {
+        if (asyncProfilerService != null && asyncProfilerService.isContinuousProfilingActive()) {
+            Pyroscope.LabelsWrapper.run(labels, c);
+        } else {
+            c.run();
+        }
+    }
+}

--- a/src/main/java/com/taboola/async_profiler/spring/AsyncProfilerEndpointConfig.java
+++ b/src/main/java/com/taboola/async_profiler/spring/AsyncProfilerEndpointConfig.java
@@ -1,5 +1,6 @@
 package com.taboola.async_profiler.spring;
 
+import com.taboola.async_profiler.api.LabelsWrapper;
 import com.taboola.async_profiler.api.continuous.pyroscope.PyroscopeReporterConfig;
 import io.pyroscope.okhttp3.OkHttpClient;
 import org.springframework.beans.factory.annotation.Value;
@@ -100,6 +101,7 @@ public class AsyncProfilerEndpointConfig {
                 asyncProfilerConfig,
                 threadUtils);
 
+        LabelsWrapper.setAsyncProfilerService(asyncProfilerService);
         return asyncProfilerService;
     }
 


### PR DESCRIPTION
`Pyroscope.LabelsWrapper` assumes that underlying `AsyncProfiler` instance is ready, or can be initialized with default lib path, without correctly taking `PyroscopeAsyncProfiler` into account. 
Add a new `LabelsWrapper` adaptor that takes continuous profiling status into account, which also indicates readiness of underlying initialization.