### PR TITLE
Feature/support spring2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
 
     <properties>
         <slf4j.version>1.7.13</slf4j.version>
-        <com.taboola.spring.version>5.3.31</com.taboola.spring.version>
         <com.taboola.spring.boot.version>2.7.18</com.taboola.spring.boot.version>
         <com.taboola.lombok.version>1.18.10</com.taboola.lombok.version>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -65,16 +64,6 @@
             <groupId>io.pyroscope</groupId>
             <artifactId>agent</artifactId>
             <version>0.13.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>${com.taboola.spring.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>${com.taboola.spring.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.taboola</groupId>
     <artifactId>async-profiler-actuator-endpoint</artifactId>
-    <version>2.0.7</version>
+    <version>2.0.8</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Async Profiler Actuator Endpoint</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.taboola</groupId>
     <artifactId>async-profiler-actuator-endpoint</artifactId>
-    <version>2.0.8</version>
+    <version>3.0.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Async Profiler Actuator Endpoint</description>
@@ -48,8 +48,8 @@
 
     <properties>
         <slf4j.version>1.7.13</slf4j.version>
-        <com.taboola.spring.version>4.3.23.RELEASE</com.taboola.spring.version>
-        <com.taboola.spring.boot.version>1.5.20.RELEASE</com.taboola.spring.boot.version>
+        <com.taboola.spring.version>5.3.31</com.taboola.spring.version>
+        <com.taboola.spring.boot.version>2.7.18</com.taboola.spring.boot.version>
         <com.taboola.lombok.version>1.18.10</com.taboola.lombok.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -75,6 +75,11 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <version>${com.taboola.spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <version>${com.taboola.spring.boot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/taboola/async_profiler/spring/AsyncProfilerEndpoint.java
+++ b/src/main/java/com/taboola/async_profiler/spring/AsyncProfilerEndpoint.java
@@ -1,8 +1,6 @@
 package com.taboola.async_profiler.spring;
 
-import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
-import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
-import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -15,7 +13,7 @@ import com.taboola.async_profiler.api.continuous.ContinuousProfilingSnapshotRequ
 import com.taboola.async_profiler.api.facade.ProfileRequest;
 import com.taboola.async_profiler.api.facade.ProfileResult;
 
-@Endpoint(id = "async-profiler")
+@RestControllerEndpoint(id = "async-profiler")
 public class AsyncProfilerEndpoint {
 
     public static final String BINARY_PROFILE_ATTACHMENT_HEADER_VALUE = "attachment; filename=profile.";
@@ -26,7 +24,6 @@ public class AsyncProfilerEndpoint {
         this.asyncProfilerService = asyncProfilerService;
     }
 
-    @WriteOperation
     @GetMapping(value = "/profile", produces = MediaType.ALL_VALUE)
     public ResponseEntity profile(ProfileRequest profileRequest) {
         ProfileResult profileResult = asyncProfilerService.profile(profileRequest);
@@ -34,7 +31,6 @@ public class AsyncProfilerEndpoint {
         return toResponseEntity(profileResult);
     }
 
-    @WriteOperation
     @GetMapping(value = "/stop", produces = MediaType.ALL_VALUE)
     public ResponseEntity stop() {
         ProfileResult profileResult = asyncProfilerService.stop();
@@ -42,7 +38,6 @@ public class AsyncProfilerEndpoint {
         return toResponseEntity(profileResult);
     }
 
-    @WriteOperation
     @GetMapping(value = "/start-continuous", produces = MediaType.ALL_VALUE)
     @ResponseBody
     public String startContinuous(ContinuousProfilingSnapshotRequest snapshotRequest) {
@@ -51,7 +46,6 @@ public class AsyncProfilerEndpoint {
         return "Started continuous profiling with: " + snapshotRequest;
     }
 
-    @WriteOperation
     @GetMapping(value = "/stop-continuous", produces = MediaType.ALL_VALUE)
     @ResponseBody
     public String stopContinuous() {
@@ -60,14 +54,12 @@ public class AsyncProfilerEndpoint {
         return "Stopped continuous profiling";
     }
 
-    @ReadOperation
     @GetMapping(value = "/events")
     @ResponseBody
     public String getSupportedEvents() {
         return asyncProfilerService.getSupportedEvents();
     }
 
-    @ReadOperation
     @GetMapping(value = "/version")
     @ResponseBody
     public String getVersion() {

--- a/src/main/java/com/taboola/async_profiler/spring/AsyncProfilerEndpoint.java
+++ b/src/main/java/com/taboola/async_profiler/spring/AsyncProfilerEndpoint.java
@@ -1,7 +1,8 @@
 package com.taboola.async_profiler.spring;
 
-import org.springframework.boot.actuate.endpoint.Endpoint;
-import org.springframework.boot.actuate.endpoint.mvc.MvcEndpoint;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -14,33 +15,18 @@ import com.taboola.async_profiler.api.continuous.ContinuousProfilingSnapshotRequ
 import com.taboola.async_profiler.api.facade.ProfileRequest;
 import com.taboola.async_profiler.api.facade.ProfileResult;
 
-public class AsyncProfilerEndpoint implements MvcEndpoint {
+@Endpoint(id = "async-profiler")
+public class AsyncProfilerEndpoint {
 
     public static final String BINARY_PROFILE_ATTACHMENT_HEADER_VALUE = "attachment; filename=profile.";
 
     private final AsyncProfilerService asyncProfilerService;
-    private final boolean isSensitive;
 
-    public AsyncProfilerEndpoint(AsyncProfilerService asyncProfilerService, boolean isSensitive) {
+    public AsyncProfilerEndpoint(AsyncProfilerService asyncProfilerService) {
         this.asyncProfilerService = asyncProfilerService;
-        this.isSensitive = isSensitive;
     }
 
-    @Override
-    public String getPath() {
-        return "/async-profiler";
-    }
-
-    @Override
-    public boolean isSensitive() {
-        return isSensitive;
-    }
-
-    @Override
-    public Class<? extends Endpoint> getEndpointType() {
-        return null;
-    }
-
+    @WriteOperation
     @GetMapping(value = "/profile", produces = MediaType.ALL_VALUE)
     public ResponseEntity profile(ProfileRequest profileRequest) {
         ProfileResult profileResult = asyncProfilerService.profile(profileRequest);
@@ -48,6 +34,7 @@ public class AsyncProfilerEndpoint implements MvcEndpoint {
         return toResponseEntity(profileResult);
     }
 
+    @WriteOperation
     @GetMapping(value = "/stop", produces = MediaType.ALL_VALUE)
     public ResponseEntity stop() {
         ProfileResult profileResult = asyncProfilerService.stop();
@@ -55,6 +42,7 @@ public class AsyncProfilerEndpoint implements MvcEndpoint {
         return toResponseEntity(profileResult);
     }
 
+    @WriteOperation
     @GetMapping(value = "/start-continuous", produces = MediaType.ALL_VALUE)
     @ResponseBody
     public String startContinuous(ContinuousProfilingSnapshotRequest snapshotRequest) {
@@ -63,6 +51,7 @@ public class AsyncProfilerEndpoint implements MvcEndpoint {
         return "Started continuous profiling with: " + snapshotRequest;
     }
 
+    @WriteOperation
     @GetMapping(value = "/stop-continuous", produces = MediaType.ALL_VALUE)
     @ResponseBody
     public String stopContinuous() {
@@ -71,12 +60,14 @@ public class AsyncProfilerEndpoint implements MvcEndpoint {
         return "Stopped continuous profiling";
     }
 
+    @ReadOperation
     @GetMapping(value = "/events")
     @ResponseBody
     public String getSupportedEvents() {
         return asyncProfilerService.getSupportedEvents();
     }
 
+    @ReadOperation
     @GetMapping(value = "/version")
     @ResponseBody
     public String getVersion() {

--- a/src/main/java/com/taboola/async_profiler/spring/AsyncProfilerEndpointConfig.java
+++ b/src/main/java/com/taboola/async_profiler/spring/AsyncProfilerEndpointConfig.java
@@ -3,7 +3,7 @@ package com.taboola.async_profiler.spring;
 import com.taboola.async_profiler.api.LabelsWrapper;
 import com.taboola.async_profiler.api.continuous.pyroscope.PyroscopeReporterConfig;
 import io.pyroscope.okhttp3.OkHttpClient;
-import org.springframework.beans.factory.annotation.Value;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -30,7 +30,7 @@ import java.time.Duration;
 public class AsyncProfilerEndpointConfig {
 
     @Bean
-    @ConfigurationProperties("com.taboola.asyncProfiler")
+    @ConfigurationProperties("com.taboola.async-profiler")
     public AsyncProfilerServiceConfigurations asyncProfilerServiceConfigurations() {
         return new AsyncProfilerServiceConfigurations();
     }
@@ -106,8 +106,7 @@ public class AsyncProfilerEndpointConfig {
     }
 
     @Bean
-    public AsyncProfilerEndpoint asyncProfilerEndpoint(AsyncProfilerService asyncProfilerService,
-                                                       @Value("${com.taboola.asyncProfilerEndpoint.sensitive:false}") boolean isSensitive) {
-        return new AsyncProfilerEndpoint(asyncProfilerService, isSensitive);
+    public AsyncProfilerEndpoint asyncProfilerEndpoint(AsyncProfilerService asyncProfilerService) {
+        return new AsyncProfilerEndpoint(asyncProfilerService);
     }
 }

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.taboola.async_profiler.spring.AsyncProfilerEndpointConfig

--- a/src/test/java/com/taboola/async_profiler/spring/AsyncProfilerEndpointTest.java
+++ b/src/test/java/com/taboola/async_profiler/spring/AsyncProfilerEndpointTest.java
@@ -1,9 +1,7 @@
 package com.taboola.async_profiler.spring;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -39,7 +37,7 @@ public class AsyncProfilerEndpointTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        asyncProfilerEndPoint = new AsyncProfilerEndpoint(asyncProfilerService, false);
+        asyncProfilerEndPoint = new AsyncProfilerEndpoint(asyncProfilerService);
     }
 
     @Test
@@ -114,11 +112,5 @@ public class AsyncProfilerEndpointTest {
     public void testGetVersion() {
         when(asyncProfilerService.getProfilerVersion()).thenReturn("1");
         assertEquals("1", asyncProfilerEndPoint.getVersion());
-    }
-
-    @Test
-    public void testIsSensitive() {
-        assertFalse(new AsyncProfilerEndpoint(asyncProfilerService, false).isSensitive());
-        assertTrue(new AsyncProfilerEndpoint(asyncProfilerService, true).isSensitive());
     }
 }


### PR DESCRIPTION
This FB main goal is to migrate current implementation to Spring2.7.18 implementation.
Which raised in 
https://github.com/taboola/async-profiler-actuator-endpoint/issues/12